### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/benchmark-manual.yml
+++ b/.github/workflows/benchmark-manual.yml
@@ -3,6 +3,9 @@ name: Benchmarks
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   benchmark:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Potential fix for [https://github.com/reach2sayan/ExpressionDifferentiator/security/code-scanning/7](https://github.com/reach2sayan/ExpressionDifferentiator/security/code-scanning/7)

Add an explicit `permissions` block to the workflow so the `GITHUB_TOKEN` is least-privileged.  
Best fix here: define workflow-level permissions right after the `on` block:

- `contents: read`

This is sufficient for `actions/checkout@v4` and does not change behavior of the benchmark steps. Since no job appears to need write scopes, avoid granting them.  
File to edit: `.github/workflows/benchmark-manual.yml` near the top-level keys (`name`, `on`, `jobs`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
